### PR TITLE
feat: 모달 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="modal"></div>
     <!--[if IE]>
       <div id="ieGuide">
         <h1>Please get out of here. We dont want you.</h1>

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -69,6 +69,11 @@
     height: 60px;
     background: url('../../assets/svgs/arrow_prev.svg') no-repeat center/70% auto;
   }
+  &.customBack {
+    width: 60px;
+    height: 60px;
+    background: url('../../assets/svgs/arrow_prev.svg') no-repeat center/70% auto;
+  }
 
   &.like {
   }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import styles from './button.module.scss'
 
 interface Props {
-  type: 'back' | 'like' | 'more' | 'primary' | 'secondary' | 'negative'
+  type: 'back' | 'like' | 'more' | 'primary' | 'secondary' | 'negative' | 'customBack'
   onClick?: () => void
   text?: string
   submit?: true

--- a/src/components/Modal/ModalLayout.tsx
+++ b/src/components/Modal/ModalLayout.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from 'react'
+import { ModalPortal } from 'utils/portal'
+import styles from './modal.module.scss'
+
+interface Props {
+  children: ReactNode
+  show: boolean
+}
+
+const ModalLayout = ({ children, show }: Props) => {
+  return show ? (
+    <ModalPortal>
+      <div className={styles.outer}>
+        <div className={styles.backGround}>
+          <div className={styles.inner}>{children}</div>
+        </div>
+      </div>
+    </ModalPortal>
+  ) : null
+}
+
+export default ModalLayout

--- a/src/components/Modal/TwoButtonModal.tsx
+++ b/src/components/Modal/TwoButtonModal.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import ModalLayout from './ModalLayout'
+import styles from './modal.module.scss'
+
+interface Props {
+  show: boolean
+  close: () => void
+  message: string
+  yesCallBack: () => void
+}
+
+const TwoButtonModal = ({ show, close, message, yesCallBack }: Props) => {
+  return (
+    <ModalLayout show={show}>
+      <div className={styles.twoButton_container}>
+        <p>{message}</p>
+        <section className={styles.twoButton_buttonSection}>
+          <button type='button' onClick={yesCallBack}>
+            예
+          </button>
+          <button type='button' onClick={close}>
+            아니오
+          </button>
+        </section>
+      </div>
+    </ModalLayout>
+  )
+}
+
+export default TwoButtonModal

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default as TwoButtonModal } from './TwoButtonModal'

--- a/src/components/Modal/modal.module.scss
+++ b/src/components/Modal/modal.module.scss
@@ -1,0 +1,74 @@
+@use 'styles/constants/sizes';
+@use '/src/styles/constants/colors';
+@use '/src/styles/mixins/vwConvert';
+@use 'src/styles/mixins/fontSize';
+
+.outer {
+  position: fixed;
+  z-index: 10001;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  @media (max-width: sizes.$SCREEN_SM) {
+    @include vwConvert.mo(top, 0);
+    @include vwConvert.mo(bottom, 0);
+    @include vwConvert.mo(left, 0);
+    @include vwConvert.mo(right, 0);
+  }
+}
+
+.backGround {
+  width: 100%;
+  height: 100%;
+  max-width: 768px;
+  background: rgba(81, 81, 81, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.inner {
+  background-color: #fff;
+  width: 90%;
+  max-width: 738px;
+  border-radius: 7px;
+  @media (max-width: sizes.$SCREEN_SM) {
+    max-width: 400px;
+  }
+}
+
+.twoButton {
+  &_container {
+    text-align: center;
+    p {
+      padding: 24px 0px;
+      border-bottom: 1px solid colors.$GRAY_CF;
+      @media (max-width: sizes.$SCREEN_SM) {
+        @include vwConvert.mo(padding, 24 0);
+        @include fontSize.emFontSizeMO(16);
+      }
+    }
+  }
+
+  &_buttonSection {
+    width: 100%;
+    display: flex;
+    flex: 1 1;
+    button {
+      width: 100%;
+      padding: 20px 0px;
+      @media (max-width: sizes.$SCREEN_SM) {
+        @include vwConvert.mo(padding, 20 0);
+        @include fontSize.emFontSizeMO(16);
+      }
+      &:first-child {
+        border-right: 1px solid colors.$GRAY_CF;
+      }
+    }
+  }
+}

--- a/src/components/Modal/modal.module.scss
+++ b/src/components/Modal/modal.module.scss
@@ -14,12 +14,6 @@
   height: 100%;
   display: flex;
   justify-content: center;
-  @media (max-width: sizes.$SCREEN_SM) {
-    @include vwConvert.mo(top, 0);
-    @include vwConvert.mo(bottom, 0);
-    @include vwConvert.mo(left, 0);
-    @include vwConvert.mo(right, 0);
-  }
 }
 
 .backGround {

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,22 @@
+import { Dispatch, SetStateAction, useCallback, useState } from 'react'
+
+type ReturnType = {
+  isOpen: boolean
+  onClose: () => void
+  setIsOpen: Dispatch<SetStateAction<boolean>>
+}
+
+const useModal = (): ReturnType => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const onClose = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+  return {
+    isOpen,
+    onClose,
+    setIsOpen,
+  }
+}
+
+export default useModal

--- a/src/pages/LocalAuth/index.tsx
+++ b/src/pages/LocalAuth/index.tsx
@@ -5,12 +5,16 @@ import SearchBar from 'components/SearchBar'
 import RegionList from 'components/RegionList'
 import { getRegions } from 'apis/region'
 import { useNavigate } from 'react-router-dom'
+import useModal from 'hooks/useModal'
+import { TwoButtonModal } from 'components/Modal'
 import styles from './localAuth.module.scss'
 
 const LocalAuth = () => {
   const [regions, setRegions] = useState<Array<string>>([])
   const [searchValue, setSearchValue] = useState<string>('')
   const [myRegion, setMyRegion] = useState<string>('')
+
+  const { isOpen, onClose, setIsOpen } = useModal()
 
   const navigate = useNavigate()
 
@@ -39,8 +43,8 @@ const LocalAuth = () => {
   )
   return (
     <>
+      <Header leftChild={<Button type='customBack' onClick={() => setIsOpen(true)} />} />
       <div className={styles.wrapper}>
-        <Header leftChild={<Button type='back' />} />
         <h1 style={{ paddingBottom: 16 }}>내 동네 설정하기</h1>
         <SearchBar value={searchValue} onChange={onChangeSearchValue} onSearch={onSearch} />
       </div>
@@ -56,6 +60,14 @@ const LocalAuth = () => {
           isDisabled={myRegion === ''}
         />
       </div>
+      <TwoButtonModal
+        show={isOpen}
+        close={onClose}
+        message='회원가입을 종료하시겠습니까?'
+        yesCallBack={() => {
+          navigate('/')
+        }}
+      />
     </>
   )
 }

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -26,3 +26,4 @@ $PRIMARY: #87e0ac;
 $WARNING: #ff6d6a;
 $INDIGO: #6f7bd4;
 $GRAY_D9: #d9d9d9;
+$GRAY_CF: #cfcfcf;

--- a/src/utils/portal.ts
+++ b/src/utils/portal.ts
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+export const ModalPortal = ({ children }: { children: ReactNode }) => {
+  return createPortal(children, document.getElementById('modal')!)
+}


### PR DESCRIPTION
## 제목
[모달 작업] React Portal 사용하여 모달을 구현하였습니다.

## 작업내용
- [x] 기능 추가 : 모달 구현

## 수정내용
### utils 폴더에 portal.ts 추가 
- 사실 굳이 portal.ts를 분리할 필요는 없긴 하지만 추후에 portal을 더 추가한다면 해당 파일에 createProtal을 모아서 사용하는게 좋다고 생각해서 파일을 분리하였습니다.
### hooks 폴더 추가
- 모달 사용시 isOpen, onClose 이런 state를 반복적으로 사용해주어야 하기 때문에 custom hooks로 따로 만들어 작업했습니다. useDebuonce도 이 폴더로 옮기면 좋을 것 같습니다!
### componets/modal 폴더 추가 
- modal 이란 폴더를 만들어서 모달 관련된 파일들을 전부 여기서 작업 했습니다. index.ts에서 export하고 있는데, 지금은 모달 디자인이 하나지만 혹시 모달 디자인이 추가 된다면 여기 폴더에 모달 컴포넌트를 만들어서 export하려고 합니다. 
- modal layout이 div를 3개나 감싸고 있는데 원리 outer / inner 모양이었으나, pc 화면에서 background를 가운데 정렬하기가 힘들어서 그냥 background 용 div를 하나 더 추가했습니다. 더 좋은 방법 있으면 말씀해 주세요
### Button 컴포넌트 type 추가 
- 디자인 상 회원가입 단계에서 back버튼을 누르면 뒤로가는게 아니라 회원가입 종료 모달이 나와야 합니다. 기존 type='back'의 버튼은 onClick을 넣을 수 없어 customBack이라는 타입을 추가하고 해당 타입은 back type의 css를 똑같이 복붙 했습니다.

## 주의 사항
- pages/LocalAuth를 보시면 useModal hook을 사용하는 방법을 알 수 있습니다. 
### useModal hook 내용
- isOpen: isOpen이 true면 모달이 뜹니다. (기본값 false)
- onClose: 모달을 닫는 함수입니다. 
- setIsOpen: isOpen을 true로 만들 때 쓰는 handler
