### PR TITLE
fix: 로그아웃 버그 수정 및 프로필 수정 이후 쿼리 키 초기화

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -27,3 +27,13 @@ export const isAxiosError = <E>(err: unknown | AxiosError<E>): err is AxiosError
 
 export const defaultInstance = axiosApi()
 export const authInstance = axiosAuthApi()
+
+authInstance.interceptors.request.use((config) => {
+  const token = localStorage.getItem('sobunsobun')
+  if (!config.headers || !token) return config
+  const headerToken = config.headers.SOBUNSOBUN
+  if (headerToken === token) return config
+
+  config.headers.SOBUNSOBUN = token
+  return config
+})

--- a/src/pages/Profile/Current.tsx
+++ b/src/pages/Profile/Current.tsx
@@ -34,8 +34,7 @@ const ProfileCurrent = () => {
         // eslint-disable-next-line no-console
         console.log(res)
         localStorage.setItem('sobunsobun', '')
-        // queryClient.invalidateQueries(['myInfo'])
-        queryClient.cancelQueries(['myInfo'])
+        queryClient.resetQueries()
         navigate('/login')
       })
       .catch((error) => {
@@ -54,7 +53,8 @@ const ProfileCurrent = () => {
         console.log(res)
         localStorage.setItem('sobunsobun', '')
         // queryClient.invalidateQueries(['myInfo'])
-        queryClient.cancelQueries(['myInfo'])
+        // queryClient.cancelQueries(['myInfo'])
+        queryClient.removeQueries()
         navigate('/login')
       })
       .catch((error) => {

--- a/src/pages/Profile/Edit.tsx
+++ b/src/pages/Profile/Edit.tsx
@@ -125,6 +125,10 @@ const ProfileEdit = () => {
     } finally {
       queryClient.invalidateQueries('myInfo')
       queryClient.invalidateQueries('feedList')
+      queryClient.invalidateQueries({
+        queryKey: ['myPost'],
+        refetchInactive: true,
+      })
     }
   }
 


### PR DESCRIPTION
## 제목
로그아웃 버그 수정 및 프로필 수정 이후 쿼리 키 초기화

## 작업내용
- [x] 버그 수정

## 수정내용
- 로그 아웃 이후에 새로고침을 안하면 로컬 스토리지에 있는 토큰 값이 들어가지 않고 이전에 설정한 토큰값이 요청에 실려서 날아 갑니다.
- axios interceptor 달아서 header에 토큰이이랑 local storage에 토큰이 다르면 토큰을 최신화 하게 수정하였습니다.
- 로그 아웃 시 쿼리키를 전부 삭제 했습니다. 그냥 invalidate하니까 inactive를 refetch 하게 했더니 로그 아웃 상태에선 토큰 값이 없어서 리패치가 불가했습니다. 문서 보니까 resetQueries 이게 캐시까지 싹 날리는 것 같아서 써보니까 정상적으로 동작하는 것 같습니다 혹시 에러나면 말해주세요
- 프로필 수정 이후에도 최신화 되어야 하는 값들은 쿼리키를 초기화 하거나 리패치 해줬습니다.
- 닉네임 수정 시 관심목록에 내 게시물이 있으면 그건 그냥 리패치 안했는데 내가 쓴 게시물이 따로 페이지가 있는데 굳이 관심목록이 필요하지 않을 것 같습니다. 차라리 배포 전에 내 게시물에는 좋아요를 못 눌리게 만들면 될 것 같습니다.

